### PR TITLE
Added support for partials with relative paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,6 @@ module.exports = function(source) {
   this.cacheable && this.cacheable(true);
   var query = loaderUtils.parseQuery(this.query);
   var req = loaderUtils.getRemainingRequest(this).replace(/^!/, "");
-  var tmplFunc = slm.compile(source)
+  var tmplFunc = slm.compile(source, {filename: this.resource});
   return tmplFunc();
 }


### PR DESCRIPTION
Previously attempt to use partials like `partial('./partials/head.slm')` produced error: the "filename" option is required to use with "relative" paths'.

This fix always passes correct filename to slim compiler as an option, and now partials work without errors.
