### PR TITLE
Let slm can read data from loader config

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function(source) {
   if (!options.basePath && resolveRoot) options.basePath = resolveRoot;
   options.filename = this.resource;
   var tmplFunc = slm.compile(source, options);
-  
+
   // watch for changes in every referenced file
   Object.keys(slm.template.VM.prototype._cache).forEach(function(dep) {
     this.addDependency(dep);
@@ -29,6 +29,6 @@ module.exports = function(source) {
   Object.keys(slm.template.VM.prototype._cache).forEach(function(dep) {
     delete slm.template.VM.prototype._cache[dep];
   });
-  
-  return tmplFunc();
+
+  return tmplFunc(options.data || options || {});
 };


### PR DESCRIPTION
Hi, I notice current slm-loader cannot pass any data into slm template.
I just make a little change, it could help user inject data into their template.

For example,

```
config.module.slmLoader = {
  data: { title: "Hello World" }
}
```

Can use like below in slm

```
doctype html5
head
  title
    = this.title
```

And this change also prevent user can directly access system information.
The `slm` default will put all environment into it, so I can user like `this.process.versions.node` to know about which version of current using node.
