### PR TITLE
Upgrade to version 1.0.0 of slm

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/wealthbar/slm-loader#readme",
   "dependencies": {
     "loader-utils": "^0.2.15",
-    "slm": "^0.5.1",
+    "slm": "^1.0.0",
     "slm-markdown": "^1.0.0"
   }
 }


### PR DESCRIPTION
I'm using version 1.0.0 of slm locally by overriding the dependency in my `package.json` file and it seems to work fine.